### PR TITLE
Removed useless strict mode

### DIFF
--- a/client/scripts/basics.js
+++ b/client/scripts/basics.js
@@ -1,5 +1,3 @@
-"use strict";
-
 export const websiteContentContainer = document.getElementById("websiteContentContainer");
 export const favicon = document.getElementById('favicon');
 

--- a/client/scripts/currentVideoDownloads.js
+++ b/client/scripts/currentVideoDownloads.js
@@ -1,5 +1,4 @@
 import * as basic from "../scripts/basics.js";
-"use strict";
 
 let VideoDownloadDetailsInterval, show_current_downloads_clicked;
 

--- a/client/scripts/index.js
+++ b/client/scripts/index.js
@@ -3,7 +3,6 @@ import * as basic from "../scripts/basics.js";
 import * as navigationBar from "../scripts/navigationBar.js";
 import * as showAvailableVideos from "../scripts/showAvailableVideos.js";
 import * as currentVideoDownloads from "../scripts/currentVideoDownloads.js";
-"use strict";
 
 // get video link and video type from the url
 function showVideoFromUrl(url) {

--- a/client/scripts/navigationBar.js
+++ b/client/scripts/navigationBar.js
@@ -2,7 +2,6 @@ import * as basic from "../scripts/basics.js";
 import * as showAvailableVideos from "../scripts/showAvailableVideos.js";
 import * as index from "../scripts/index.js";
 import * as currentVideoDownloads from "../scripts/currentVideoDownloads.js";
-"use strict";
 
 // load header details into html using headerContainer id
 export function loadNavigationBar(path) {

--- a/client/scripts/showAvailableVideos.js
+++ b/client/scripts/showAvailableVideos.js
@@ -1,6 +1,5 @@
 import * as basic from "../scripts/basics.js";
 import * as currentVideoDownloads from "../scripts/currentVideoDownloads.js";
-"use strict";
 
 // try to fetch for all-available-video-data is successful send data to eachAvailableVideoDetails function else show error msg
 async function loadVideoDetails() {

--- a/client/scripts/videoPlayerButtons.js
+++ b/client/scripts/videoPlayerButtons.js
@@ -1,5 +1,5 @@
 import * as basic from "../scripts/basics.js";
-"use strict";
+
 let fileNameID;
 
 // controlBar at the top of the video player

--- a/package-lock.json
+++ b/package-lock.json
@@ -905,9 +905,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"


### PR DESCRIPTION
ES Modules are already in strict mode. No need for the "use strict" at the top.

See [https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#strict_mode_for_modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#strict_mode_for_modules) for more info.